### PR TITLE
entwicklung: add *.meta.js for entwicklungsliste

### DIFF
--- a/entwicklung/entwicklungsliste.meta.js
+++ b/entwicklung/entwicklungsliste.meta.js
@@ -1,0 +1,17 @@
+// ==UserScript==
+// @name Entwicklungsliste
+// @namespace coolcow.dyndns.org
+// @description Script zum Uebertrag von Schiffsplaenen aus dem Sternenbund nach Revorix
+// @author coolius
+// @contributor Lord-FaKe
+// @contributor   Wintermoon
+// @downloadURL https://raw.githubusercontent.com/tpummer/gm-revorix/master/entwicklung/Revorix_Sternenbund_Importer.user.js
+// @updateURL https://raw.githubusercontent.com/tpummer/gm-revorix/master/entwicklung/Revorix_Sternenbund_Importer.user.js
+// @include http*revorix.info/php/entwicklung_neu.php*
+// @version 3.2017040102
+// @run-at document-idle
+// @require http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
+// @grant GM_setValue
+// @grant GM_getValue
+// @grant unsafeWindow
+// ==/UserScript==


### PR DESCRIPTION
This should solve the renaming problem, I think. Since [this change](https://github.com/greasemonkey/greasemonkey/commit/523bbd15885ecc8ce89278aa63893d978834ec72) GM will look for `<script>.meta.js`, and we can use that nicely to let the users resp. their browser auto-update whenever they feel like. This meta should lead them to the renamed script which may even supply a newer version in the future, making the user update twice in a row. Hopefully. Or stuff just breaks because GM does not recognize it as an valid update \^^

I'll leave the actual rename and whether a meta for the new name will be provided to the maintainer.