### PR TITLE
Update Bauzeit-Script

### DIFF
--- a/bauzeiten/revorix.bauzeit.meta.js
+++ b/bauzeiten/revorix.bauzeit.meta.js
@@ -1,0 +1,12 @@
+// ==UserScript==
+// @name            Revorix Bauzeit-Script
+// @namespace       http://toasten.de/
+// @description     Dieses Script erweitert die Bau-Anzeige. Es zeigt an, wann ein Bau abgeschlossen wird.
+// @version         3.2.210919
+//
+// @updateURL       https://github.com/tpummer/gm-revorix/raw/master/bauzeiten/revorix.bauzeit.meta.js
+// @downloadURL     https://github.com/tpummer/gm-revorix/raw/master/bauzeiten/revorix.bauzeit.user.js
+//
+// @grant           none
+// @include         http*revorix.de/*/bau.php*
+// ==/UserScript==

--- a/bauzeiten/revorix.bauzeit.user.js
+++ b/bauzeiten/revorix.bauzeit.user.js
@@ -1,190 +1,155 @@
 // ==UserScript==
-// @name          Revorix Bauzeit-Script
-// @namespace     http://toasten.de/
-// @description	  Dieses Script erweitert die Bau-Anzeige. Es zeigt an, wann ein Bau abgeschlossen wird.
-// @version       3.1.210919
-// @grant       none
-// @include http*revorix.de/*/bau.php*
+// @name            Revorix Bauzeit-Script
+// @namespace       http://toasten.de/
+// @description     Dieses Script erweitert die Bau-Anzeige. Es zeigt an, wann ein Bau abgeschlossen wird.
+// @version         3.2.210919
+//
+// @updateURL       https://github.com/tpummer/gm-revorix/raw/master/bauzeiten/revorix.bauzeit.meta.js
+// @downloadURL     https://github.com/tpummer/gm-revorix/raw/master/bauzeiten/revorix.bauzeit.user.js
+//
+// @grant           none
+// @include         http*revorix.de/*/bau.php*
 // ==/UserScript==
 
 /*
-* made by
-* toasten
-* added init after load by coolius
+Originally created by toasten
 */
-var isOpera = "Opera" == navigator.appName;
-var isFireFox = "Netscape" == navigator.appName;
-var isChrome = "Netscape" == navigator.appName && navigator.appVersion.indexOf("Chrome") > -1;
+(function () {
+  "use strict";
 
+  var isOpera = "Opera" == navigator.appName;
+  var isFireFox = "Netscape" == navigator.appName;
 
-var now = (new Date()).getTime();
+  var now = new Date().getTime();
+  var tage = new Array("So", "Mo", "Di", "Mi", "Do", "Fr", "Sa");
 
+  function initBauzeit() {
+    var tables = document.getElementsByTagName("table");
+    var text = "";
 
+    for (var i = 0; i < tables.length; i++) {
+      var trelemente = tables[i].getElementsByTagName("tr");
 
-function initBauzeit()
-{
-	var tables = document.getElementsByTagName('table');
-	var text="";
+      if (isOpera) {
+        text = trelemente[0].innerText;
+      } else {
+        text = trelemente[0].textContent;
+      }
 
-	for (var i=0; i < tables.length; i++)
-	{
-		var trelemente = tables[i].getElementsByTagName('tr');
+      if (text.indexOf("Interner Ausbau") > -1) {
+        markGeb(trelemente);
+      }
+    }
+  }
 
-		if(isOpera)
-		{
-			text = trelemente[0].innerText;
-		}
-		else
-		{
-			text = trelemente[0].textContent;
-		}
-		
-		if(text.indexOf("Interner Ausbau") > -1)
-		{
-			markGeb(trelemente);
-		}
-	}
-	
-}
+  function markGeb(trelemente) {
+    var lastSekunden = 0;
 
+    for (var i = 2; i < trelemente.length; i++) {
+      var tr = trelemente[i];
+      var tdelemente = tr.getElementsByTagName("td");
+      var zeittd;
 
+      if (tdelemente.length == 18) {
+        // Gebäude-Name bzw. Zeile mit Dauer für nächstes Level
+        var td = tdelemente[0];
+        var text = getTDText(td);
 
+        var s = text.indexOf("(");
+        var geb = text.substring(0, s - 1);
 
-function markGeb(trelemente){
+        if ("Nächstes Level" == geb) {
+          // bspw. "Nächstes Level (87)"
+          zeittd = tdelemente[16];
+          let sekunden = getSekunden(getTDText(zeittd));
+          let fertig = new Date(now + sekunden * 1000);
+          let datestr = formatDate(fertig);
 
-	var lastSekunden = "";
+          zeittd.innerHTML +=
+            "<br/><div style='color:orange'>" + datestr + "</div>";
+        } else {
+          //18 Tage 00:27:00
+          zeittd = tdelemente[16];
+          let sekunden = getSekunden(getTDText(zeittd));
+          let fertig = new Date(now + sekunden * 1000);
+          let datestr = formatDate(fertig);
 
-// trelemente.length  5  
+          zeittd.innerHTML +=
+            "<br/><div style='color:orange'>" + datestr + "</div>";
+        }
+      } else if (tdelemente.length == 4) {
+        // Gebäude aktuell im Ausbau
+        zeittd = tdelemente[2];
+        // Zeit zumindest unter Chromium nicht als Text abgrabschbar
+        const timerDiv = zeittd.querySelector("div[id^=timer]")
+        let remainingTime;
+        if (timerDiv && timerDiv.firstChild) {
+          // Daten für Timer holen und zerlegen
+          // 33115|3702840|400
+          let splits = timerDiv.firstChild.data.split('|')
+          remainingTime = splits[1] - splits[0]
+        }
+        let fertig = new Date(now + remainingTime * 1000);
+        zeittd.innerHTML +=
+          "<br/><div style='color:orange; float:right;'>" +
+          formatDate(fertig) +
+          "</div>";
+      } else {
+        // Ressourcen-Header, seltsame leere Zeilen, Gebäude-Gruppe ("Interner Ausbau", ...)
+      }
+    }
+  }
 
-	for (var i=2; i < trelemente.length; i++)
-	{
-		var tr = trelemente[i];
-		var tdelemente = tr.getElementsByTagName('td');
-        var zeittd;
+  function formatDate(datum) {
+    //Fertig: 19.08.2011 07:07:00
+    let value = tage[datum.getDay()] + " ";
+    value += datum.getDate() + ".";
+    value +=
+      (isFireFox || isOpera ? 1 + datum.getMonth() : datum.getMonth()) + " ";
+    value +=
+      (isFireFox || isOpera ? 1900 + datum.getYear() : datum.getYear()) + " ";
+    value +=
+      (datum.getHours() < 10 ? "0" + datum.getHours() : datum.getHours()) + ":";
+    value +=
+      (datum.getMinutes() < 10
+        ? "0" + datum.getMinutes()
+        : datum.getMinutes()) + ":";
+    value +=
+      datum.getSeconds() < 10 ? "0" + datum.getSeconds() : datum.getSeconds();
 
-		if(tdelemente.length==18)
-		{
-			var td = tdelemente[0];
-			var text = getTDText(td);
+    return value;
+  }
 
-			var s = text.indexOf('(');
-			var e = text.indexOf(')');
-			var geb = text.substring(0,s-1);
+  function getSekunden(zeit) {
+    let split = zeit.split(" ");
+    let sekunden;
 
-			if("Nächstes Level" == geb){
-				zeittd = tdelemente[16];
-				sekunden = getSekunden(getTDText(zeittd));
-				fertig = new Date(now+((lastSekunden+sekunden)*1000));
+    if (split.length >= 3) {
+      sekunden = split[0] * 24 * 60 * 60;
+      sekunden += getSekundenFromStunden(split[2]);
+      return sekunden;
+    } else {
+      sekunden = getSekundenFromStunden(split[0]);
+      return sekunden;
+    }
+  }
 
-				//alert(now+"--"+fertig.toLocaleString());
-				zeittd.innerHTML += "<br/><div style='color:orange'>"+formatDate(fertig)+"</div>";
-			}
-			else{
-				//18 Tage 00:27:00
-				zeittd = tdelemente[16];
-				lastSekunden = getSekunden(getTDText(zeittd));
-				fertig = new Date(now+(lastSekunden*1000));
-				
-				//alert(now+"--"+fertig.toLocaleString());
-				zeittd.innerHTML += "<br/><div style='color:orange'>"+formatDate(fertig)+"</div>";
-			}
-		}
-		else if(tdelemente.length==4){
-		
-			zeittd = tdelemente[2];
-			lastSekunden = getSekunden(getTDText(zeittd).trim());
-//console.log(lastSekunden);
-            fertig = new Date(now+(lastSekunden*1000));
-			zeittd.innerHTML += "<br/><div style='color:orange; float:right;'>"+formatDate(fertig)+"</div>";
-			
-		}
-		else{
-			//alert("g"+tdelemente.length);
-		}
-	}
+  function getSekundenFromStunden(zeit) {
+    let split = zeit.split(":");
+    let sekunden;
+    sekunden = split[0] * 60 * 60;
+    sekunden += split[1] * 60;
+    sekunden += split[2] * 1;
+    return sekunden;
+  }
 
-}
+  function getTDText(td) {
+    if (isOpera) {
+      return td.innerText;
+    } else {
+      return td.textContent;
+    }
+  }
 
-
-function trim10 (str) {
-	var whitespace = ' \n\r\t\f\x0b\xa0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000';
-	for (var i = 0; i < str.length; i++) {
-		if (whitespace.indexOf(str.charAt(i)) === -1) {
-			str = str.substring(i);
-			break;
-		}
-	}
-	for (i = str.length - 1; i >= 0; i--) {
-		if (whitespace.indexOf(str.charAt(i)) === -1) {
-			str = str.substring(0, i + 1);
-			break;
-		}
-	}
-	return whitespace.indexOf(str.charAt(0)) === -1 ? str : '';
-}
-
-
-
-function formatDate(datum){
-
-	tage = new Array();
-	tage[0] = "So";
-	tage[1] = "Mo";
-	tage[2] = "Di";
-	tage[3] = "Mi";
-	tage[4] = "Do";
-	tage[5] = "Fr";
-	tage[6] = "Sa";
-
-	//Fertig: 19.08.2011 07:07:00
-	value = tage[datum.getDay()]+" ";
-	value += datum.getDate()+".";
-	value += (isFireFox||isOpera?(1+datum.getMonth()):datum.getMonth())+" ";
-	value += (isFireFox||isOpera?(1900+datum.getYear()):datum.getYear())+" ";
-	value += (datum.getHours()<10?"0"+datum.getHours():datum.getHours())+":";
-	value += (datum.getMinutes()<10?"0"+datum.getMinutes():datum.getMinutes())+":";
-	value += (datum.getSeconds()<10?"0"+datum.getSeconds():datum.getSeconds());
-	return value;
-}
-
-
-function getSekunden(zeit){
-    var split = zeit.split(" ");
-
-    if(split.length >= 3){
-		sekunden = split[0]*24*60*60;
-		sekunden += getSekundenFromStunden(split[2]);
-		return sekunden;
-	}
-	else{
-		sekunden = getSekundenFromStunden(split[0]);
-		return sekunden;
-	}
-}
-
-
-function getSekundenFromStunden(zeit){
-	var split = zeit.split(":");
-	sekunden = split[0] * 60 * 60;
-	sekunden += split[1] * 60;
-	sekunden += split[2] * 1;
-	return sekunden;
-}
-
-
-function getTDText(td){
-	if(isOpera)
-	{
-		return td.innerText;
-	}
-	else
-	{
-		return td.textContent;
-	}
-}
-
-initBauzeit();
-window.addEventListener('load', function() {
-/*Start des ganzes Systems*/
-    initBauzeit();
-}, false);
+  initBauzeit();
+})();


### PR DESCRIPTION
Das Bauzeit-Script lief zumindest unter Chromium nicht mehr sauber bei mir.

- Kleines Refactoring der gröbsten Schnitzer vorgenommen
- ESLint ein wenig glücklicher gemacht
- doppelte + kaputte generierte Zeiten korrigiert
- Datumsgenerierung für aktuell laufenden Ausbau korrigiert

Ist immer noch nicht schön, aber immerhin selten und funzt erstmal wieder.